### PR TITLE
Solving Minor Parser Problem

### DIFF
--- a/app/src/FScheme/Parser/Parser.hs
+++ b/app/src/FScheme/Parser/Parser.hs
@@ -139,9 +139,9 @@ parseDottedList parseElem =
 
 parseExpr :: Parser LispVal
 parseExpr = parseString
-        <|> parseAtom
         <|> parseNumber 'd'
         <|> (char '#' >> ((oneOf "bodx" >>= parseNumber) <|> parseLiteral))
+        <|> parseAtom
         <|> parseQuoted
         <|> parseBackquoted
         <|> do


### PR DESCRIPTION
When tried to Parse a number with the format `#<det><number>` it was recognized before as an atom. The only thing that was needed was moving the order in which the parser tries.