### PR TITLE
Low-hanging fruit

### DIFF
--- a/src/FScheme/Core/Environment.hs
+++ b/src/FScheme/Core/Environment.hs
@@ -1,7 +1,6 @@
 module FScheme.Core.Environment where
 
 import Control.Monad.Except
-import Control.Monad.IO.Class
 import Data.IORef
 import Data.Maybe
 import FScheme.Core.Error
@@ -11,25 +10,9 @@ import Util.Flow
 
 type Env = IORef [(String, IORef LispVal)]
 
-{-
-  Cheat-sheet:
-  1. liftIO takes an IO wrapped value and "recontextualizes" it into
-    another MonadIO.
-  2. newIORef takes a value, constructs an IORef and wraps it in the
-    IO monad.
-  3. readIORef takes a value passed to an IORef and wraps it in the IO
-    monad.
-  4. writeIORef takes an IORef, a value and presumably overwrites it.
-    An empty type IO monad is returned - I presume - because of convenience.
-
-  All the functions in here build from these first principles.
--}
-
--- Creates a "null" env i.e. an empty tuple list
 nullEnv :: IO Env
 nullEnv = newIORef []
 
--- Self-explanatory
 isBound :: Env -> String -> IO Bool
 isBound envRef var = isJust . lookup var <$> readIORef envRef
 
@@ -41,7 +24,6 @@ getVar envRef var = do
     (liftIO . readIORef)
     (lookup var env)
 
--- Self-explanatory
 setVar :: Env -> String -> LispVal -> IOThrowsError LispVal
 setVar envRef var value = do
   env <- liftIO $ readIORef envRef

--- a/src/FScheme/Core/Environment.hs
+++ b/src/FScheme/Core/Environment.hs
@@ -6,6 +6,7 @@ import Data.Maybe
 import FScheme.Core.Error
 import FScheme.Core.Types
 import FScheme.Primitive.Functions
+import Control.Monad.IO.Class (liftIO)
 import Util.Flow
 
 type Env = IORef [(String, IORef LispVal)]

--- a/src/FScheme/Core/Evaluator.hs
+++ b/src/FScheme/Core/Evaluator.hs
@@ -19,12 +19,6 @@ eval env (List [Atom "backquote", List vals]) = List <$> mapM (evalBackquote env
   where
     evalBackquote domain (List [Atom "unquote", val]) = eval domain val
     evalBackquote domain val = eval domain $ List [Atom "quote", val]
-
-{- (DONE)
-Instead of treating any non-false value as true, change the definition
-of if so that the predicate accepts only Bool values and throws an error
-on any others.
--}
 eval env (List [Atom "if", prop, conseq, alt]) =
   do
     result <- eval env prop
@@ -32,19 +26,6 @@ eval env (List [Atom "if", prop, conseq, alt]) =
       Bool True -> eval env conseq
       Bool False -> eval env alt
       badForm -> throwError $ BadSpecialForm "Unrecognized special form" badForm
-
-{-
-    evalCond env (List [pred@(Bool _), action]) = eval env action
-    evalCond env (List [Atom "else", action]) = eval env action
-    evalCond env (List [pred, Atom "=>", action] : cs) = evalCond env (List [pred, action] : cs)
-    evalCond env (List [pred, action] : cs) = do
-      result <- eval env pred
-      case result of
-        Bool True -> eval env action
-        Bool False -> evalCond env cs
-        badForm -> throwError $ BadSpecialForm "Unrecognized special form" badForm
-    evalCond env [badForm] = throwError $ BadSpecialForm "Unrecognized special form" badForm
--}
 eval env (List [Atom "set!", Atom var, form]) =
   eval env form >>= setVar env var
 eval env (List (Atom "define" : List (Atom var : specs) : corpus)) =

--- a/src/FScheme/Core/Types.hs
+++ b/src/FScheme/Core/Types.hs
@@ -29,6 +29,7 @@ showVal :: LispVal -> String
 showVal (String contents) = "\"" ++ contents ++ "\""
 showVal (Atom name) = name
 showVal (Number contents) = show contents
+showVal (Float x) = show x
 showVal (Bool True) = "#t"
 showVal (Bool False) = "#f"
 showVal (Character literal) = [literal]
@@ -45,7 +46,6 @@ showVal (Func {params = args, varargs = vargs, body = _, closure = _}) =
            Just arg -> " . " ++ arg
        )
     ++ ") ...)"
-showVal (Float x) = show x
 
 unwordsList :: [LispVal] -> String
 unwordsList = unwords . map showVal


### PR DESCRIPTION
- Remove excercise comments
- Change order in which elements are parsed to avoid conflicts
- Created dedicated boolean parser so as not to create conflict with the parsing of strings, atoms and numbers in non-decimal base